### PR TITLE
handler: Add handler for supervisord

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ kong_log_dir: /var/log/kong
 kong_conf_general_prefix:   /usr/local/kong/
 kong_conf_general_log_level: notice
 kong_conf_general_anonymous_report: "on"
+
+# kong_daemon_manager: [binary|supervisor]
+#  binary: use the kong binary directly
+#  supervisor: use supervisorctl module
+kong_daemon_manager: "binary"
+
+# Ensure kong is started
+kong_service_start: false
+# Allow kong restart/reload
+kong_service_restart: false
+
+# If you use kong with supervisord, provide the application name declared
+kong_supervisor_app_name: kong
 ```
 
 ##### Kong `Nginx` configuration

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,5 +82,15 @@ kong_conf_miscellaneous_lua_code_cache: "on"
 kong_conf_miscellaneous_lua_package_path: ""
 kong_conf_miscellaneous_lua_package_cpath: ""
 
+# kong_daemon_manager: [binary|supervisor]
+#  binary: use the kong binary directly
+#  supervisor: use supervisorctl module
+kong_daemon_manager: "binary"
+
+# Ensure kong is started
 kong_service_start: false
-kong_service_reload: false
+# Allow kong restart/reload
+kong_service_restart: false
+
+# If you use kong with supervisord, provide the application name declared
+kong_supervisor_app_name: kong

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,3 +83,4 @@ kong_conf_miscellaneous_lua_package_path: ""
 kong_conf_miscellaneous_lua_package_cpath: ""
 
 kong_service_start: false
+kong_service_reload: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,3 +81,5 @@ kong_conf_miscellaneous_lua_ssl_verify_depth: 1
 kong_conf_miscellaneous_lua_code_cache: "on"
 kong_conf_miscellaneous_lua_package_path: ""
 kong_conf_miscellaneous_lua_package_cpath: ""
+
+kong_service_start: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,29 @@
 ---
-- name: start kong
-  command: /usr/local/bin/kong start
 
-- name: reload kong
+##########
+# binary
+##########
+
+- name: start kong binary
+  command: /usr/local/bin/kong start
+  when: kong_service_start | bool
+
+- name: restart kong binary
   command: /usr/local/bin/kong reload
-  when: kong_service_reload
+  when: kong_service_restart | bool
+
+##########
+# supervisor
+##########
+
+- name: start kong supervisor
+  supervisorctl:
+    name: "{{ kong_supervisor_app_name }}"
+    state: started
+  when: kong_service_start | bool
+
+- name: restart kong supervisor
+  supervisorctl:
+    name: "{{ kong_supervisor_app_name }}"
+    state: restarted
+  when: kong_service_restart | bool

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: start kong
+  command: /usr/local/bin/kong start
+
+- name: reload kong
+  command: /usr/local/bin/kong reload
+

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,4 +4,4 @@
 
 - name: reload kong
   command: /usr/local/bin/kong reload
-
+  when: kong_service_reload

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
   template:
     src: etc/kong/kong.conf.j2
     dest: "{{ kong_conf_dest }}"
-  notify: reload kong
+  notify: "restart kong {{ kong_daemon_manager }}"
 
 - name: Ensure log service directory exists
   file:
@@ -44,5 +44,5 @@
   command: "ps auxw"
   changed_when: ps_output.stdout.find('kong -c nginx.conf') == -1
   register: ps_output
-  notify: start kong
-  when: kong_service_start
+  notify: "start kong {{ kong_daemon_manager }}"
+  when: kong_service_start | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,7 @@
   template:
     src: etc/kong/kong.conf.j2
     dest: "{{ kong_conf_dest }}"
+  notify: reload kong
 
 - name: Ensure log service directory exists
   file:
@@ -38,3 +39,9 @@
     owner: "{{ kong_user }}"
     group: "{{ kong_group }}"
     mode: 0755
+
+- name: Detecting if kong running
+  command: "ps auxw"
+  changed_when: ps_output.stdout.find('kong -c nginx.conf') == -1
+  register: ps_output
+  notify: start kong

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,3 +45,4 @@
   changed_when: ps_output.stdout.find('kong -c nginx.conf') == -1
   register: ps_output
   notify: start kong
+  when: kong_service_start


### PR DESCRIPTION
If you prefer to run kong via supervisord instead of binary directly,
the new variables allow you to choose between both.